### PR TITLE
Feature/notify pull subjects conflict

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -513,8 +513,10 @@ class ExternalModule extends AbstractExternalModule {
                 $data = $data[$mappings['event_id']];
                 $diff = [];
 
+                $subject_data_array = json_decode(json_encode($subject_data), true);
+
                 foreach ($mappings['mappings'] as $key => $field) {
-                    $value = $subject_data['data']->{$key};
+                    $value = $this->digNestedData($subject_data_array, $key);
                     if ($value === null) {
                         $value = '';
                     }
@@ -657,5 +659,22 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         return $output;
+    }
+    function digNestedData($subject_data_array, $key) {
+        $value = null;
+        if (property_exists($subject_data_array, $key)) {
+            $value = $subject_data_array->{$key};
+        } else {
+            // keys nested in objects were not being found
+            array_walk_recursive($subject_data_array,
+                                 function($v, $k) use ($key, &$value) {
+                                     if ("$key" == "$k") {
+                                         $value = $v;
+                                     }
+                                 }
+            );
+        }
+
+        return $value;
     }
 }

--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -47,8 +47,11 @@ class SubjectDiff extends Entity {
         $record = $mappings['PrimaryIdentifier'] == $table_pk ? $this->data['data']['PrimaryIdentifier'] : getAutoId();
         $record = Records::addNewRecordToCache($record, $arm, $event_id);
 
+        $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
+
         foreach ($mappings['mappings'] as $key => $field) {
-            $data[$field] = $remote_data->{$key};
+            $value = ExternalModule::digNestedData($remote_data_array, $key);
+            $data[$field] = $value;
         }
 
         $data = [$record => [$event_id => $data]];
@@ -97,9 +100,12 @@ class SubjectDiff extends Entity {
         $record_data = REDCap::getData($this->data['project_id'], 'array', $record, $mappings['mappings'], $event_id);
         $diff = [];
 
+        $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
+
         foreach ($mappings['mappings'] as $key => $field) {
-            if ($remote_data->{$key} !== $record_data[$field]) {
-                $diff[$key] = [$record_data[$field], $remote_data->{$key}];
+            $value = ExternalModule::digNestedData($remote_data_array, $key);
+            if ($value !== $record_data[$field]) {
+                $diff[$key] = [$record_data[$field], $value];
             }
         }
 

--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -59,8 +59,17 @@ class SubjectDiff extends Entity {
 
         $data = [$record => [$event_id => $data]];
 
-        if (!Records::saveData($this->data['project_id'], 'array', $data, 'overwrite') === true) {
+        $save_response = Records::saveData($this->data['project_id'], 'array', $data, 'overwrite');
+        if (!$save_response === true) {
             return false;
+        }
+
+        if (!empty($save_response['errors'])) {
+            foreach ($save_response['errors'] as $key => $value) {
+                $error_array = explode(",", $value); // [record, REDCap variable, OnCore value, error message]
+                $clear_error_msg = substr_replace($error_array[3], " $error_array[2]", 10, 0);
+                print_r("Error pulling record $error_array[0]. $clear_error_msg</br>");
+            }
         }
 
         if ($delete) {

--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -48,7 +48,7 @@ class SubjectDiff extends Entity {
         $record = $mappings['PrimaryIdentifier'] == $table_pk ? $this->data['data']['PrimaryIdentifier'] : getAutoId();
         }
 
-        Records::addNewRecordToCache($record, $arm, $event_id);
+        Records::addNewRecordToCache($project_id = PROJECT_ID, $record = $record, $arm_id = $arm, $event_id = $event_id);
 
         $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
 

--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -44,8 +44,11 @@ class SubjectDiff extends Entity {
         $record = $this->data['record_id'];
         $data = [];
 
+        if (empty($record)) {
         $record = $mappings['PrimaryIdentifier'] == $table_pk ? $this->data['data']['PrimaryIdentifier'] : getAutoId();
-        $record = Records::addNewRecordToCache($record, $arm, $event_id);
+        }
+
+        Records::addNewRecordToCache($record, $arm, $event_id);
 
         $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,6 @@
     "name": "OnCore Client",
     "namespace": "OnCoreClient\\ExternalModule",
     "description": "Provides integration with OnCore SIP and SOAP APIs to get protocol and enrollment data into REDCap. <strong><a href=\"https://github.com/ctsit/redcap_oncore_client\">See full documentation here</a></strong>.",
-    "framework-version": 3,
     "permissions": [
         "redcap_every_page_top",
         "redcap_module_system_enable",


### PR DESCRIPTION
Pull OnCore Subjects no longer fails silently. Reports a detailed error message for each record that failed to pull.

To test functionality:

1. Go to a project with OnCore Client configured
2. Set a REDCap variable that an OnCore variable is mapped to to be of a type other than text box (e.g. Multiple choice drop down or radio buttons), set up coded variables
3. Attempt to Pull OnCore Subjects