### PR TITLE
check verson number and adjust addNewRecord function call accordingly

### DIFF
--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -49,7 +49,13 @@ class SubjectDiff extends Entity {
         $record = $mappings['PrimaryIdentifier'] == $table_pk ? $this->data['data']['PrimaryIdentifier'] : getAutoId();
         }
 
-        Records::addNewRecordToCache($project_id = PROJECT_ID, $record = $record, $arm_id = $arm, $event_id = $event_id);
+        // check version due to 9+ requring the $project_id parameter be set without a default
+        if ( (explode('.', REDCAP_VERSION)[0]) >= 9 ) {
+            Records::addNewRecordToCache($project_id = PROJECT_ID, $record = $record, $arm_id = $arm, $event_id = $event_id);
+        } else {
+            Records::addNewRecordToCache($record = $record, $arm_id = $arm, $event_id = $event_id);
+        }
+
 
         $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
 


### PR DESCRIPTION
Addresses reappearance of issue #23 

REDCap 9+ requires `project_id` be set but does _not_ have a default like the others, causing the parameter ordering issue that was missed in the short 8.11.2 testing as it required a clash with `record` and `project_id` to appear.