### PR TITLE
Feature/allow use redcap user inst id

### DIFF
--- a/classes/entity/SubjectDiff.php
+++ b/classes/entity/SubjectDiff.php
@@ -49,7 +49,13 @@ class SubjectDiff extends Entity {
         $record = $mappings['PrimaryIdentifier'] == $table_pk ? $this->data['data']['PrimaryIdentifier'] : getAutoId();
         }
 
-        Records::addNewRecordToCache($project_id = PROJECT_ID, $record = $record, $arm_id = $arm, $event_id = $event_id);
+        // check version due to 9+ requring the $project_id parameter be set without a default
+        if ( (explode('.', REDCAP_VERSION)[0]) >= 9 ) {
+            Records::addNewRecordToCache($project_id = PROJECT_ID, $record = $record, $arm_id = $arm, $event_id = $event_id);
+        } else {
+            Records::addNewRecordToCache($record = $record, $arm_id = $arm, $event_id = $event_id);
+        }
+
 
         $remote_data_array = (json_decode(json_encode($remote_data), true)); // Converts nested objects to arrays
 

--- a/classes/entity/list/SubjectsDiffList.php
+++ b/classes/entity/list/SubjectsDiffList.php
@@ -73,32 +73,49 @@ class SubjectsDiffList extends EntityList {
             return;
         }
 
-        if ($server_var = $this->module->getSystemSetting('staff_id_server_variable_name')) {
+        if ( ($this->module->getSystemSetting('autopopulate_staff_id')) && ($server_var = $this->module->getSystemSetting('staff_id_server_variable_name')) ) {
             if ($server_val = $_SERVER[$server_var]) {
                 // Create or update user credentials
-                // hack to make user_id a pseudo primary key
-                if ($id = $this->entityFactory->query('oncore_staff_identifier')->condition('user_id', USERID)->execute()) {
-                    $id = array_values($id)[0]->getId();
-                }
-                $entity = $this->entityFactory->getInstance('oncore_staff_identifier', $id); // null id defaults to a new entry
 
-                if ($entity->setData(['staff_id' => $server_val,
-                                                   'user_id' => USERID])) {
-                    $entity->save();
+                if ($this->module->getSystemSetting('use_custom_database') == "1") {
+                    // hack to make user_id a pseudo primary key
+                    if ($id = $this->entityFactory->query('oncore_staff_identifier')->condition('user_id', USERID)->execute()) {
+                        $id = array_values($id)[0]->getId();
+                    }
+                    $entity = $this->entityFactory->getInstance('oncore_staff_identifier', $id); // null id defaults to a new entry
+
+                    if ($entity->setData(['staff_id' => $server_val,
+                                'user_id' => USERID])) {
+                        $entity->save();
+                    } else {
+                        //TODO: handle errors with entity setData if they arise
+                    }
                 } else {
-                    // TODO: handle errors
+                    // do server stuff
+                    $sql = "UPDATE redcap_user_information SET user_inst_id='" . $server_val . "' WHERE username='" . USERID . "'";
+                    $this->module->query($sql);
                 }
             }
         }
 
-        $query = $this->entityFactory->query('oncore_staff_identifier', $id);
+        $query = $this->entityFactory->query('oncore_protocol_staff');
+
         $query
-            ->addField('a.stop_date', 'stop_date')
-            ->addField('a.protocol_no', 'protocol_no')
-            ->join('redcap_entity_oncore_protocol_staff', 'a', 'e.staff_id = a.staff_id')
-            ->condition('e.user_id', USERID)
-            ->condition('protocol_no', $protocol_no)
-            ->execute();
+            ->addField('e.stop_date', 'stop_date')
+            ->addField('e.staff_id', 'staff_id')
+            ->addField('e.protocol_no', 'protocol_no')
+            ->condition('protocol_no', $protocol_no);
+
+        if ($this->module->getSystemSetting('use_custom_database') == "1") {
+            $query
+                ->join('redcap_entity_oncore_staff_identifier', 'a', 'staff_id = a.staff_id')
+                ->condition('a.user_id', USERID);
+        } else {
+            $sql = "SELECT user_inst_id FROM redcap_user_information WHERE username='" . USERID . "'";
+            $query->condition('staff_id', ($this->module->query($sql)->fetch_assoc()['user_inst_id']));
+        }
+
+        $query->execute();
         $sql_result = array_values($query->getRawResults())[0];
 
         if (!$sql_result && (SUPER_USER != 1)) {

--- a/config.json
+++ b/config.json
@@ -118,9 +118,33 @@
             "type": "checkbox"
         },
         {
+            "key": "use_custom_database",
+            "name": "Use REDCap or Entity database?",
+            "type": "radio",
+            "choices": [
+                {
+                    "value": "0",
+                    "name": "REDCap Database"
+                },
+                {
+                    "value": "1",
+                    "name": "Entity Database"
+                }
+            ]
+        },
+        {
+            "key": "autopopulate_staff_id",
+            "name": "Auto-populate Institution ID from server?</br>(warning, this will overwrite the value in your database)",
+            "type": "checkbox"
+        },
+        {
             "key": "staff_id_server_variable_name",
             "name": "Name of server variable used to populate Institution ID",
-            "type": "text"
+            "type": "text",
+            "branchingLogic": {
+                "field": "autopopulate_staff_id",
+                "value": true
+            }
         }
     ],
     "project-settings": [


### PR DESCRIPTION
Addresses issue #32 

Improves UI for selecting a server variable to populate the user's institution ID, also allows institution ID to be read from (and, if autopopulation from sever is enabled, stored) in the custom redcap entity database or in `redcap_user_information.user_inst_id`.

The Control Center's Enter User Institution IDs does not update the `redcap_user_information` table, this may need to be stated clearly.