### PR TITLE
enable access to SequenceNumber

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -430,11 +430,13 @@ class ExternalModule extends AbstractExternalModule {
                 continue;
             }
 
+            $complete_subject_data = array_merge((array) $subject->Subject, (array) $subject->OnStudyData);
+
             $data = [
                 'subject_id' => $subject->Subject->PrimaryIdentifier,
                 'protocol_no' => $result->ProtocolNo,
                 'status' => $status,
-                'data' => json_encode($subject->Subject),
+                'data' => json_encode($complete_subject_data),
             ];
 
             $factory->create('oncore_subject', $data);
@@ -558,7 +560,7 @@ class ExternalModule extends AbstractExternalModule {
                 $data = $data[$mappings['event_id']];
                 $diff = [];
 
-                $subject_data_array = json_decode(json_encode($subject_data), true);
+                $subject_data_array = json_decode(json_encode($subject_data), true); // needed for flattening nested properties
 
                 foreach ($mappings['mappings'] as $key => $field) {
                     $value = $this->digNestedData($subject_data_array, $key);

--- a/config.json
+++ b/config.json
@@ -221,6 +221,11 @@
                     "required": true
                 },
                 {
+                    "key": "sequence_number",
+                    "name": "SequenceNumber",
+                    "type": "field-list"
+                },
+                {
                     "key": "first_name",
                     "name": "FirstName",
                     "type": "field-list"

--- a/config.json
+++ b/config.json
@@ -221,11 +221,6 @@
                     "required": true
                 },
                 {
-                    "key": "sequence_number",
-                    "name": "SequenceNumber",
-                    "type": "field-list"
-                },
-                {
                     "key": "first_name",
                     "name": "FirstName",
                     "type": "field-list"
@@ -322,6 +317,16 @@
                             "type": "field-list"
                         }
                     ]
+                },
+                {
+                    "key": "id",
+                    "name": "id",
+                    "type": "field-list"
+                },
+                {
+                    "key": "sequence_number",
+                    "name": "SequenceNumber",
+                    "type": "field-list"
                 }
             ]
         }


### PR DESCRIPTION
Partially addresses issue #37 
SequenceNumber is accessible and works as expected

Scraping in subject ID is a little more complicated; it _is_ returned from OnCore under the key `id`, but the module is coercing all variables (hardcoded in `config.json`) to PascalCase causing `id` to be mapped to `Id`.

We could attempt to map it elsewhere, get rid of conversion PascalCase, or ignore it.