### PR TITLE
trim values on fetch so diff won't flag whitespace

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -563,7 +563,7 @@ class ExternalModule extends AbstractExternalModule {
                 $subject_data_array = json_decode(json_encode($subject_data), true); // needed for flattening nested properties
 
                 foreach ($mappings['mappings'] as $key => $field) {
-                    $value = $this->digNestedData($subject_data_array, $key);
+                    $value = trim($this->digNestedData($subject_data_array, $key)); // trim to avoid erroneous diffs on _all_ values
                     if ($value === null) {
                         $value = '';
                     }


### PR DESCRIPTION
Addresses issue #39

OnCore Data was already being `trim`med by REDCap core function `Records::saveData`, OnCore data will now be `trim`med as well to make accurate diffs against REDCap; REDCap data will remain inaccurate in regards to OnCore's real data.