### PR TITLE
remove leftover field for subject ID

### DIFF
--- a/config.json
+++ b/config.json
@@ -319,11 +319,6 @@
                     ]
                 },
                 {
-                    "key": "id",
-                    "name": "id",
-                    "type": "field-list"
-                },
-                {
                     "key": "sequence_number",
                     "name": "SequenceNumber",
                     "type": "field-list"


### PR DESCRIPTION
Removes leftover option in `config.json` from PR #38, noted [in this comment.](https://github.com/ctsit/redcap_oncore_client/issues/37#issuecomment-519080607)