### PR TITLE
create initial working version of summary accrual

### DIFF
--- a/OnCoreSummaryAccrual_project_template.xml
+++ b/OnCoreSummaryAccrual_project_template.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="OnCore Summary Accrual Data Template" AsOfDateTime="2019-11-22T16:56:43" CreationDateTime="2019-11-22T16:56:43" SourceSystem="REDCap" SourceSystemVersion="9.1.1">
+<Study OID="Project.OnCoreSummaryAccrualDataTempla">
+<GlobalVariables>
+	<StudyName>OnCore Summary Accrual Data Template</StudyName>
+	<StudyDescription>This file contains the metadata, events, and data for REDCap project "OnCore Summary Accrual Data Template".</StudyDescription>
+	<ProtocolName>OnCore Summary Accrual Data Template</ProtocolName>
+	<redcap:RecordAutonumberingEnabled>1</redcap:RecordAutonumberingEnabled>
+	<redcap:CustomRecordLabel></redcap:CustomRecordLabel>
+	<redcap:SecondaryUniqueField></redcap:SecondaryUniqueField>
+	<redcap:SchedulingEnabled>0</redcap:SchedulingEnabled>
+	<redcap:SurveysEnabled>0</redcap:SurveysEnabled>
+	<redcap:SurveyInvitationEmailField></redcap:SurveyInvitationEmailField>
+	<redcap:Purpose>4</redcap:Purpose>
+	<redcap:PurposeOther></redcap:PurposeOther>
+	<redcap:ProjectNotes></redcap:ProjectNotes>
+</GlobalVariables>
+<MetaDataVersion OID="Metadata.OnCoreSummaryAccrualDataTempla_2019-11-22_1656" Name="OnCore Summary Accrual Data Template" redcap:RecordIdField="record_id">
+	<FormDef OID="Form.oncore_data_template" Name="OnCore Data Template" Repeating="No" redcap:FormName="oncore_data_template">
+		<ItemGroupRef ItemGroupOID="oncore_data_template.record_id" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="oncore_data_template.oncore_data_template_complete" Mandatory="No"/>
+	</FormDef>
+	<ItemGroupDef OID="oncore_data_template.record_id" Name="OnCore Data Template" Repeating="No">
+		<ItemRef ItemOID="record_id" Mandatory="No" redcap:Variable="record_id"/>
+		<ItemRef ItemOID="onstudydate" Mandatory="No" redcap:Variable="onstudydate"/>
+		<ItemRef ItemOID="gender" Mandatory="No" redcap:Variable="gender"/>
+		<ItemRef ItemOID="race" Mandatory="No" redcap:Variable="race"/>
+		<ItemRef ItemOID="ethnicity" Mandatory="No" redcap:Variable="ethnicity"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="oncore_data_template.oncore_data_template_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="oncore_data_template_complete" Mandatory="No" redcap:Variable="oncore_data_template_complete"/>
+	</ItemGroupDef>
+	<ItemDef OID="record_id" Name="record_id" DataType="text" Length="999" redcap:Variable="record_id" redcap:FieldType="text">
+		<Question><TranslatedText>Record ID</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="onstudydate" Name="onstudydate" DataType="date" Length="999" redcap:Variable="onstudydate" redcap:FieldType="text" redcap:TextValidationType="date_mdy">
+		<Question><TranslatedText>On study date</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="gender" Name="gender" DataType="text" Length="1" redcap:Variable="gender" redcap:FieldType="radio">
+		<Question><TranslatedText>Gender</TranslatedText></Question>
+		<CodeListRef CodeListOID="gender.choices"/>
+	</ItemDef>
+	<ItemDef OID="race" Name="race" DataType="text" Length="2" redcap:Variable="race" redcap:FieldType="radio">
+		<Question><TranslatedText>Race</TranslatedText></Question>
+		<CodeListRef CodeListOID="race.choices"/>
+	</ItemDef>
+	<ItemDef OID="ethnicity" Name="ethnicity" DataType="text" Length="1" redcap:Variable="ethnicity" redcap:FieldType="radio">
+		<Question><TranslatedText>Ethnicity</TranslatedText></Question>
+		<CodeListRef CodeListOID="ethnicity.choices"/>
+	</ItemDef>
+	<ItemDef OID="oncore_data_template_complete" Name="oncore_data_template_complete" DataType="text" Length="1" redcap:Variable="oncore_data_template_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="oncore_data_template_complete.choices"/>
+	</ItemDef>
+	<CodeList OID="gender.choices" Name="gender" DataType="text" redcap:Variable="gender">
+		<CodeListItem CodedValue="F"><Decode><TranslatedText>Female</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="M"><Decode><TranslatedText>Male</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="B"><Decode><TranslatedText>Both</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="race.choices" Name="race" DataType="text" redcap:Variable="race">
+		<CodeListItem CodedValue="01"><Decode><TranslatedText>White</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="03"><Decode><TranslatedText>Black or African American</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="04"><Decode><TranslatedText>Native Hawaiian or Other Pacific Islander</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="05"><Decode><TranslatedText>Asian</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="06"><Decode><TranslatedText>American Indian or Alaska Native</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="07"><Decode><TranslatedText>Subject Refused</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="99"><Decode><TranslatedText>Unknown</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="ethnicity.choices" Name="ethnicity" DataType="text" redcap:Variable="ethnicity">
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Hispanic or Latino</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Non-Hispanic</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="3"><Decode><TranslatedText>Subject Refused</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="9"><Decode><TranslatedText>Unknown</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+	<CodeList OID="oncore_data_template_complete.choices" Name="oncore_data_template_complete" DataType="text" redcap:Variable="oncore_data_template_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+</MetaDataVersion>
+</Study>
+<ClinicalData StudyOID="Project.OnCoreSummaryAccrualDataTempla" MetaDataVersionOID="Metadata.OnCoreSummaryAccrualDataTempla_2019-11-22_1656">
+</ClinicalData>
+</ODM>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Go to **Control Center > External Modules**, click on OnCore Client's configure 
 - **Password**: Your OnCore client password
 - **Protocol lookup method**: The method through which protocols are acquired from OnCore (SIP or UF OCR API) - _one_ of these is required to associate projects with protocols
 - **SIP URL**: The URL of OnCore SIP (Study Information Portal), e.g. `https://example.edu/sip/SIPMain`. Returns **only** protocols open to enrollment
-- **OCR API URL**: The URL of UF OCR OnCore API (Application Programming Interface), e.g. `https://example.edu/ocr/api/protocols`. Returns **all** protocols, requires UF OCR API credentials
+- **OCR API URL**: The URL of UF OCR OnCore API (Application Programming Interface), e.g. `https://example.edu/ocr/api`. Returns **all** protocols, requires UF OCR API credentials
   - **OCR API Username**: Your UF OCR OnCore API user name
   - **OCR API Key**: Your UF OCR OnCore API key
 - **Log requests**: Check this field to log all API requests (see Logs Page section) - this is useful for development purposes and testing

--- a/classes/entity/list/SummaryAccrualList.php
+++ b/classes/entity/list/SummaryAccrualList.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OnCoreClient\Entity;
+
+use OnCoreClient\ExternalModule\ExternalModule;
+use RCView;
+use REDCapEntity\EntityList;
+
+class SummaryAccrualList extends EntityList {
+
+    protected $linkToRecordEnabled = false;
+
+    protected function renderPageBody() {
+
+        if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+            if (isset($_POST['oncore_sa_send'])) {
+                $this->module->sendSummaryAccrualData();
+            }
+        }
+
+        $this->cssFiles[] = $this->module->getUrl('css/summary_accrual.css');
+
+        // TODO: store responses and integrate with Entity
+        parent::renderPageBody();
+    }
+
+    protected function renderAddButton() {
+        $btn = RCView::i(['class' => 'fas fa-upload']);
+        $btn = RCView::button([
+            'type' => 'submit',
+            'name' => 'oncore_sa_send',
+            'class' => 'btn btn-primary btn-sm',
+        ], $btn . ' Send Summary Accrual Data');
+
+        echo RCView::form(['id' => 'oncore-sa-send', 'method' => 'post'], $btn);
+    }
+
+}

--- a/config.json
+++ b/config.json
@@ -162,6 +162,11 @@
             ]
         },
         {
+            "key": "using_sa_template",
+            "name": "Using a Summary Accrual Template?",
+            "type": "checkbox"
+        },
+        {
             "key": "valid_statuses",
             "name": "Pull subjects having the following statuses",
             "type": "sub_settings",
@@ -344,6 +349,11 @@
                 "name": "Pull OnCore Subjects",
                 "icon": "arrow_rotate_clockwise",
                 "url": "plugins/subjects_pull.php"
+            },
+            {
+                "name": "Upload Summary Accrual",
+                "icon": "arrow_up",
+                "url": "plugins/summary_accrual_upload.php"
             }
         ]
     }

--- a/css/summary_accrual.css
+++ b/css/summary_accrual.css
@@ -1,0 +1,3 @@
+#redcap-entity-exp-filters-form {
+    display: none;
+}

--- a/plugins/summary_accrual_upload.php
+++ b/plugins/summary_accrual_upload.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once dirname(__DIR__) . '/classes/entity/list/SummaryAccrualList.php';
+
+use OnCoreClient\Entity\SummaryAccrualList;
+
+$list = new SummaryAccrualList('oncore_summary_accrual', $module);
+$list->render('project');


### PR DESCRIPTION
Addresses issue #45 

This is the initial, minimal working code fore integration of summary accruals. It is based on the assumption that the version of the API endpoint you are communicating with will accept coded variables.

The `README` needs some work to make a viable version 1.

To test:  

1. In the **global configuration**, you must be using the `API` Protocol lookup method. Your `OCR API URL` must be `https://oncore-test.ahc.ufl.edu/ocr/api` (note this has changed from what it may have been previously!)
1. Create a project using the newly provided project XML
1. Configure the project to use protocol: `OCR23963`
1. Create one or more records, filling in field values as you wish
1. Navigate to the "Upload Summary Accrual" link in the project sidebar
1. Click the "Send Summary Accrual Data" button

Additionally, create another project to conduct routine testing procedures for "Pull OnCore Subjects" with an appropriate protocol to ensure that the change of `OCR API URL` has not altered any expected functionality.