### PR TITLE
add modal table of SA record rejects and reason

### DIFF
--- a/classes/entity/list/SummaryAccrualList.php
+++ b/classes/entity/list/SummaryAccrualList.php
@@ -4,6 +4,7 @@ namespace OnCoreClient\Entity;
 
 use OnCoreClient\ExternalModule\ExternalModule;
 use RCView;
+use REDCap;
 use REDCapEntity\EntityList;
 use REDCapEntity\StatusMessageQueue;
 
@@ -12,6 +13,54 @@ require_once dirname(__DIR__) . '/PermissionChecker.php';
 class SummaryAccrualList extends EntityList {
 
     protected $linkToRecordEnabled = false;
+
+    protected function getColsLabels() {
+        $header = parent::getColsLabels() + ['__view_data' => 'Rejections'];
+        return $header;
+    }
+
+    protected function buildTableRow($data, $entity) {
+        $row = parent::buildTableRow($data, $entity);
+        $id = $entity->getId();
+
+        $data = json_decode(json_encode($data), True);
+        $data = $data['data'];
+
+        if (empty($data['error_records'])) {
+            $row['__view_data'] = "No rejects";
+            return $row;
+        }
+
+        $row['__view_data'] = RCView::button([
+            'class' => 'btn btn-info btn-xs',
+            'data-toggle' => 'modal',
+            'data-target' => '#oncore-data-' . $id,
+        ], 'View rejects');
+
+        $error_records= [];
+
+        foreach($data['error_records'] as $err) {
+            $cause = $err['error_cause'];
+            foreach($err['id'] as $err_id) {
+                $record_link = APP_PATH_WEBROOT_FULL . 'redcap_v' . REDCAP_VERSION . DS . "DataEntry/record_home.php?pid=" . $entity->getData()['project_id'] . '&id=' . $err_id;
+                $error_records[] = ['ID' => "<a href='$record_link'>$err_id</a>", 'Error Cause' => implode(", ", $cause)];
+            }
+        }
+
+        // construct table
+        $rows = $error_records;
+        $tbody = array_reduce($rows, function($a, $b) { return $a.="<tr><td>".implode("</td><td>",$b)."</td></tr>"; });
+        $thead = "<thead class='thead-light'><tr><th>" . implode("</th><th>", array_keys($rows[0])) . "</th></tr></thead>";
+        $table = "<table class='table table-responsive-md table-striped'>$thead\n$tbody</table>";
+
+        $data = [
+            '' => $table
+        ];
+
+        include $this->module->getModulePath() . 'templates/data_modal.php';
+
+        return $row;
+    }
 
     protected function renderPageBody() {
 

--- a/plugins/summary_accrual_upload.php
+++ b/plugins/summary_accrual_upload.php
@@ -5,4 +5,5 @@ require_once dirname(__DIR__) . '/classes/entity/list/SummaryAccrualList.php';
 use OnCoreClient\Entity\SummaryAccrualList;
 
 $list = new SummaryAccrualList('oncore_summary_accrual', $module);
-$list->render('project', 'Summary Accruals');
+$list->setCols(['configuration', 'updated'])
+    ->render('project', 'Summary Accruals');


### PR DESCRIPTION
Adds a column to the table of Summary Accrual upload logs on the "Upload Summary Accrual" page (which needs a renaming). If any records were _rejected_ a "review rejects" button appears, clicking it reveals a modal dialog containing a table of record_ids and the reason(s) the OnCore API gave for rejection. The record_id links to the DataEntry page for the record.

![image](https://user-images.githubusercontent.com/20332546/81861524-609e9680-9536-11ea-8d2c-a6f77ca8f1c7.png)


To test:  
1. Open any project which has at least one summary accrual attempt, preferably with rejected records.  
1. Navigate to the "Upload Summary Accrual" page
1. Observe the new column and click any "View rejects" button
1. Confirm that the ID links to the correct location

I would like to update this table to allow the "Error Cause" field to link directly to the erroneous field, but I need to allow custom mapping of OnCore fields to REDCap fields first.