### PR TITLE
Removes block that deletes schema on disable

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -42,13 +42,6 @@ class ExternalModule extends AbstractExternalModule {
         EntityDB::buildSchema($this->PREFIX);
     }
 
-    /**
-     * @inheritdoc.
-     */
-    function redcap_module_system_disable($version) {
-        EntityDB::dropSchema($this->PREFIX);
-    }
-
     function redcap_entity_types() {
         $types = [];
 


### PR DESCRIPTION
Closes #60 

Removes __EntityDB::dropSchema($this->PREFIX);__ from __redcap_module_system_disable__ hook.